### PR TITLE
Add wide switch to get the full url

### DIFF
--- a/modules/container-orchestration-eks/readme.adoc
+++ b/modules/container-orchestration-eks/readme.adoc
@@ -288,7 +288,7 @@ postgres-678864b7-vs5zj     0/1       ContainerCreating   5          3m
 +
 [source,shell]
 ----
-kubectl get services --namespace petstore
+kubectl get services --namespace petstore -o=wide
 ----
 +
 [.output]


### PR DESCRIPTION
Due to truncated output, getting the url from this output was not possible in the terminal in Cloud9.