### PR TITLE
corrected path to container definitions template

### DIFF
--- a/modules/container-orchestration-ecs/readme.adoc
+++ b/modules/container-orchestration-ecs/readme.adoc
@@ -180,7 +180,7 @@ sed -i "s/<YourAccountID>/${ACCOUNT_ID}/" petstore-fargate-task-definition.json
 +
 [source,shell]
 ----
-aws ecs register-task-definition --cli-input-json file://~/environment/aws-modernization-workshop/modules/container-orchestration/petstore-fargate-task-definition.json
+aws ecs register-task-definition --cli-input-json file://~/environment/aws-modernization-workshop/modules/container-orchestration-ecs/petstore-fargate-task-definition.json
 ----
 
 ===== Create the Petstore Service with Amazon ECS using Fargate


### PR DESCRIPTION
command fails because the path mentioned is incorrect.