### PR TITLE
eksctl cloudformation stack name change

### DIFF
--- a/modules/container-elasticity/readme.adoc
+++ b/modules/container-elasticity/readme.adoc
@@ -310,7 +310,7 @@ deployment.extensions/cluster-autoscaler created
 +
 [source,shell]
 ----
-aws cloudformation describe-stacks --stack-name EKS-petstore-DefaultNodeGroup | jq -r ".Stacks[0].Outputs[0].OutputValue"
+aws cloudformation describe-stacks --stack-name eksctl-petstore-nodegroup-0 | jq -r ".Stacks[0].Outputs[0].OutputValue"
 ----
 +
 [.output]


### PR DESCRIPTION
Based on the resources created in the getting started eksctl cluster create command, it appears that the CFN stack name has on the node group stack is lowercase and isn't default but nodegroup-0.