### PR TITLE
Add missing namespace for kubctl scaling

### DIFF
--- a/modules/container-elasticity/readme.adoc
+++ b/modules/container-elasticity/readme.adoc
@@ -395,7 +395,7 @@ and not enough availabe it will provision new nodes for you. Let's try this.
 +
 [source,shell]
 ----
-kubectl scale deploy/frontend --namespace --replicas=10
+kubectl scale deploy/frontend --namespace petstore --replicas=10
 ----
 +
 [.output]

--- a/modules/container-elasticity/readme.adoc
+++ b/modules/container-elasticity/readme.adoc
@@ -447,7 +447,7 @@ map[cluster-autoscaler.kubernetes.io/scale-down-disabled:true node.alpha.kuberne
 +
 [source,shell]
 ----
-kubectl scale deploy/frontend --namespace --replicas=2
+kubectl scale deploy/frontend --namespace petstore --replicas=2
 ----
 +
 [.output]


### PR DESCRIPTION
Based on the resources created in the getting started eksctl cluster create command, it appears that the CFN stack name has on the node group stack is lowercase and isn't default but nodegroup-0.